### PR TITLE
Enabling prop for tablet (/showcad)

### DIFF
--- a/tablet/main.lua
+++ b/tablet/main.lua
@@ -28,15 +28,34 @@ end, false)
 
 
 function Gui(toggle)
-	SetNuiFocus(toggle, toggle)
-	guiEnabled = toggle
+  SetNuiFocus(toggle, toggle)
+  guiEnabled = toggle
 
-	SendNUIMessage({
-		type = "enableui",
-		enable = toggle
-	})
+  if guiEnabled then
+      RequestAnimDict("amb@code_human_in_bus_passenger_idles@female@tablet@base")
+      while not HasAnimDictLoaded("amb@code_human_in_bus_passenger_idles@female@tablet@base") do
+          Citizen.Wait(0)
+      end
+      local tabletModel = GetHashKey("prop_cs_tablet")
+      local bone = GetPedBoneIndex(GetPlayerPed(-1), 60309)
+      RequestModel(tabletModel)
+      while not HasModelLoaded(tabletModel) do
+          Citizen.Wait(100)
+      end
+      tabletProp = CreateObject(tabletModel, 1.0, 1.0, 1.0, 1, 1, 0)
+      AttachEntityToEntity(tabletProp, GetPlayerPed(-1), bone, 0.03, 0.002, -0.0, 10.0, 160.0, 0.0, 1, 0, 0, 0, 2, 1)
+      TaskPlayAnim(GetPlayerPed(-1), "amb@code_human_in_bus_passenger_idles@female@tablet@base", "base", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
+  else
+      DetachEntity(tabletProp, true, true)
+      DeleteObject(tabletProp)
+      TaskPlayAnim(GetPlayerPed(-1), "amb@code_human_in_bus_passenger_idles@female@tablet@base", "exit", 3.0, 3.0, -1, 49, 0, 0, 0, 0)
+  end
+
+  SendNUIMessage({
+      type = "enableui",
+      enable = toggle
+  })
 end
-
 
 AddEventHandler('onClientResourceStart', function(resourceName) --When resource starts, stop the GUI showing. 
     if(GetCurrentResourceName() ~= resourceName) then


### PR DESCRIPTION
This PR allows for other users to **visually** see another player using the cad by executing the ``/showcad`` command. 

Picture below
![7Ucw6GF](https://user-images.githubusercontent.com/53558337/97292940-36266880-184c-11eb-96db-af79fd1673e6.png)
