### PR TITLE
EVENT_DISPATCH_CLOSED error

### DIFF
--- a/sonorancad/core/httpd.lua
+++ b/sonorancad/core/httpd.lua
@@ -55,7 +55,7 @@ local PushEventHandler = {
         TriggerEvent('SonoranCAD::pushevents:DispatchEvent', GetCallCache()[body.data.dispatch.callId])
         return true
     end,
-    EVENT_DISPATCH_CLOSE = function(body)
+    EVENT_DISPATCH_CLOSED = function(body)
         local call = GetCallCache()[body.data.callId]
         if call ~= nil then
             local d = { dispatch_type = "CALL_CLOSE", dispatch = call }


### PR DESCRIPTION
Fixes error in push event where `EVENT_DISPATCH_CLOSE` was being looked for instead of `EVENT_DISPATCH_CLOSED`