### PR TITLE
fallback for web_baseUrl

### DIFF
--- a/sonorancad/core/configuration.lua
+++ b/sonorancad/core/configuration.lua
@@ -166,8 +166,10 @@ if Config.updateBranch == nil then
 	Config.updateBranch = 'master'
 end
 
-if GetConvar('web_baseUrl', '') ~= '' then
-	Config.proxyUrl = ('https://%s/sonorancad/'):format(GetConvar('web_baseUrl', ''))
+local baseUrl = GetConvar('web_baseUrl', GetConvar('sonoran_baseUrlFallback', ''))
+if baseUrl ~= '' then
+	Config.proxyUrl = ('https://%s/sonorancad/'):format(baseUrl)
+	baseUrl = nil
 end
 
 RegisterNetEvent('SonoranCAD::core:sendClientConfig')


### PR DESCRIPTION
Our server was having issues with this not loading the value, due to it not being defined in time for the resource startup perhaps? So I made a fallback value which can be set in the server.cfg.

Specifically, it was sending UNIT_LOCATION calls to the API with an unset proxyUrl, therefore never enabling body camera views in dispatch screen.