### PR TITLE
fix: Config.bodycamOverlayEnabled and Config.bodycamEnabled

### DIFF
--- a/sonorancad/core/client.lua
+++ b/sonorancad/core/client.lua
@@ -110,9 +110,11 @@ end)
 RegisterNetEvent('SonoranCAD::core::ScreenshotOff', function()
 	if Config.bodycamEnabled then
 		bodyCamOn = false
-		SendNUIMessage({
-			type = 'toggleGif'
-		})
+		if Config.bodycamOverlayEnabled then
+			SendNUIMessage({
+				type = 'toggleGif'
+			})
+		end
 		TriggerEvent('chat:addMessage', {
 			args = {
 				'Sonoran Bodycam',
@@ -146,10 +148,12 @@ RegisterNetEvent('SonoranCAD::Core::InitBodycam', function()
 					'Bodycam disabled.'
 				}
 			})
-			SendNUIMessage({
-				type = 'toggleGif',
-				location = Config.bodycamOverlayLocation
-			})
+			if Config.bodycamOverlayEnabled then
+				SendNUIMessage({
+					type = 'toggleGif',
+					location = Config.bodycamOverlayLocation
+				})
+			end
 		else
 			bodyCamOn = true
 			TriggerEvent('chat:addMessage', {
@@ -158,10 +162,12 @@ RegisterNetEvent('SonoranCAD::Core::InitBodycam', function()
 					'Bodycam enabled.'
 				}
 			})
-			SendNUIMessage({
-				type = 'toggleGif',
-				location = Config.bodycamOverlayLocation
-			})
+			if Config.bodycamOverlayEnabled then
+				SendNUIMessage({
+					type = 'toggleGif',
+					location = Config.bodycamOverlayLocation
+				})
+			end
 		end
 	end, false)
 	-- Command to change the frequency of bodycam screenshots

--- a/sonorancad/core/client.lua
+++ b/sonorancad/core/client.lua
@@ -108,19 +108,22 @@ end)
 	SonoranCAD Bodycam Callback if unit is not found in CAD
 ]]
 RegisterNetEvent('SonoranCAD::core::ScreenshotOff', function()
-	bodyCamOn = false
-	SendNUIMessage({
-		type = 'toggleGif'
-	})
-	TriggerEvent('chat:addMessage', {
-		args = {
-			'Sonoran Bodycam',
-			'Bodycam disabled - You must be in CAD to enable bodycam'
-		}
-	})
+	if Config.bodycamEnabled then
+		bodyCamOn = false
+		SendNUIMessage({
+			type = 'toggleGif'
+		})
+		TriggerEvent('chat:addMessage', {
+			args = {
+				'Sonoran Bodycam',
+				'Bodycam disabled - You must be in CAD to enable bodycam'
+			}
+		})
+	end
 end)
 
 RegisterNetEvent('SonoranCAD::Core::InitBodycam', function()
+	if Config.bodycamEnabled then
 	print('Bodycam init')
 	-- Command to toggle bodycam on and off
 	RegisterCommand(Config.bodycamCommandToggle, function(source, args, rawCommand)
@@ -209,6 +212,7 @@ RegisterNetEvent('SonoranCAD::Core::InitBodycam', function()
 			help = 'Frequency in seconds.'
 		}
 	})
+	end
 end)
 
 CreateThread(function()

--- a/sonorancad/fxmanifest.lua
+++ b/sonorancad/fxmanifest.lua
@@ -3,7 +3,7 @@ games {'gta5'}
 
 author 'Sonoran CAD'
 description 'Sonoran CAD FiveM Integration'
-version '2.9.26'
+version '2.9.27'
 
 server_scripts {
     'core/http.js'

--- a/sonorancad/version.json
+++ b/sonorancad/version.json
@@ -1,4 +1,4 @@
 {
-  "resource" : "2.9.26",
+  "resource" : "2.9.27",
   "testedFxServerVersion": "5932"
 }


### PR DESCRIPTION
Previously these settings had no effect. This PR should prevent the commands being registered, and events enabling/disabling the bodycam, and display of the overlay as expected when the appropriate Config value is changed.

Resolves issue #89 