### PR TITLE
Fix for version check on new servers where build number exceeds 10000.

### DIFF
--- a/sonorancad/core/shared_functions.lua
+++ b/sonorancad/core/shared_functions.lua
@@ -82,7 +82,8 @@ end
 function getServerVersion()
     local s = GetConvar("version", "")
     local v = s:find("v1.0.0.")
-    local i = string.gsub(s:sub(v),"v1.0.0.",""):sub(1,4)
+    local e = string.gsub(s:sub(v),"v1.0.0.","")
+    local i = e:sub(1, string.len(e) - e:find(" "))
     return i
 end
 


### PR DESCRIPTION
This applies a fix to the `getServerVersion` function causing new server that have build number in excess of 10000 to request that you update ASAP. This new fix should work regardless of how big the build number grows in the future.